### PR TITLE
Closure Based Networking

### DIFF
--- a/practiceIOS/Tee'sApp/Models/NetworkManager.swift
+++ b/practiceIOS/Tee'sApp/Models/NetworkManager.swift
@@ -7,11 +7,62 @@
 
 import Foundation
 
+enum ServiceError {
+    case invalidURL
+    case noReturnData
+    // Enum case with an "associated value" which can be passed along with the case .networkingError
+    // See how it's used in `func updatedFetchInfo(:)`
+    case networkingError(Error)
+    case decodingError(Error)
+}
+
 class NetworkManager {
+    
     let urlString = "https://jsonplaceholder.typicode.com/posts"
+    
     var data: [Info] = []
+    
      func fetchInfo(){
         performRequest(urlString: urlString)
+    }
+  
+    // The closure `completion` contains two optional values, an array of Info objects and a ServiceError
+    // ServiceError is an enum object I created above, which creates a nice way to log / send back any errors that may occur to whoever is calling this function
+    // The closure is marked as `@escaping` since this closure can "outlive the scope that you pass in", this probably doesn't make sense
+    // It basically means that this function could potentially never complete if for some reason this class was deallocated before the networking call completes
+    func updatedFetchInfo(completion: @escaping ([Info]?, ServiceError?) -> ()) {
+        guard let url = URL(string: urlString) else {
+            completion(nil, .invalidURL)
+            return
+        }
+        
+        let session = URLSession(configuration: .default)
+        session.dataTask(with: url) { data, response, error in
+            // Check for error, if we have one, return error
+            guard error == nil else {
+                // Enumerations can have "associated types", so we can pass in the actual error we get from URLSession, back in the completion handler here
+                completion(nil, .networkingError(error!))
+                return
+            }
+            
+            // Ensure we have received response data
+            guard let responseData = data else {
+                completion(nil, .noReturnData)
+                return
+            }
+            
+            // Same functionality as your `func parseJSON`
+            do {
+                // Attempt to decode into [Info]
+                let infoArray = try JSONDecoder().decode([Info].self, from: responseData)
+                // Return [Info] back in completion handler with ServiceError as nil
+                completion(infoArray, nil)
+            } catch let error {
+                // Decoding failed, send back decoding error message in completion closure
+                // Since this catch block provides us with an `error` object, we can send that back within the closure as well using our ServiceError.decodingError() which allows for an Error associated value
+                completion(nil, .decodingError(error))
+            }
+        }.resume()
     }
     
     private func performRequest(urlString: String){

--- a/practiceIOS/Tee'sApp/ViewModels/InfoViewModel.swift
+++ b/practiceIOS/Tee'sApp/ViewModels/InfoViewModel.swift
@@ -8,11 +8,53 @@
 import Foundation
 
 class InfoViewModel {
+
+    private let manager = NetworkManager()
+    // private(set) is a very nice access control modifier, allowing objects to see that InfoViewModel has a `infoData` variable, but won't let anything change the variable
+    private(set) var infoData: [Info] = []
+
     init(){
         manager.fetchInfo()
     }
-    private let manager = NetworkManager()
+
     func fetchData()->[Info]{
         manager.data
+    }
+    
+    func updatedFetchData() {
+        /*
+         Take note of the updated function structure
+         manager.updatedFetchInfo(completion: <#T##([Info]?, ServiceError?) -> ()#>)
+         
+         Expanded out, this looks like:
+         
+         manager.updatedFetchInfo { <#[Info]?#>, <#ServiceError?#> in
+             
+         }
+         
+         This is very similar to how the URLSession data task function is structure, giving us back a closure to work with
+         session.dataTask(with: <#T##URLRequest#>, completionHandler: <#T##(Data?, URLResponse?, Error?) -> Void#>)
+         
+         But now we get back a few things from our manager.updatedFetchInfo() function which we can work with
+         
+        */
+        manager.updatedFetchInfo { [weak self] infoArray, error in
+            guard error == nil else {
+                // We have received an error during our networking call, this error is of type ServiceError (which is the custom enum we created)
+                // Since we handled different errors and put these within the ServiceError enum, we now can debug easily whether it's a networking issue, decoding issue, etc
+                // this may be a good place to have an alert view pop up, notifying the user of the error
+                return
+            }
+            
+            guard let infoArray = infoArray else {
+                // If we don't have an infoArray AND if error == nil (above), then there is something we didn't handle within our NetworkManager function
+                // It wouldn't really make sense that this is nil AND we didn't get an error above
+                // print("something went really wrong, or we didn't handle the error correctly within updatedFetchInfo()")
+                return
+            }
+            
+            // At this point, we have confirmed there are no errors and we have our array full of Info objects from the server
+            self?.infoData = infoArray
+        }
     }
 }


### PR DESCRIPTION
## Summary
Update `NetworkManager` to use closures in order to nicely pass data back to the VM which is using it. The closures will contain either the decoded object OR an error describing what went wrong. This allows the VM to receive the data or handle the error accordingly.